### PR TITLE
Tested

### DIFF
--- a/src/tool-core/models/tool-core/translation_utility_functions/translation_utility_functions.xtuml
+++ b/src/tool-core/models/tool-core/translation_utility_functions/translation_utility_functions.xtuml
@@ -347,6 +347,11 @@ while ( -1 != dblspc_index )
   name = left + "_" + right;
   dblspc_index = STRING::indexof( haystack:name, needle:"  " );
 end while;
+if ( param.start_lower )
+  left = STRING::substr( s:name, begin:0, end:1 );
+  right = STRING::substr( s:name, begin:1, end:-1 );
+  name = T::sub( format:"l", s:left ) + right;
+end if;
 return T::sub( format:"r", s:name );
 // TODO make sure already camel cased does not get destroyed',
 	"ba5eda7a-def5-0000-0000-000000000004",


### PR DESCRIPTION
Fixes #12095.
Provides for lower case 1st character of already camel-cased word.